### PR TITLE
AuthMissingParameter caused by partial token clean up

### DIFF
--- a/example-common/templates/home.html
+++ b/example-common/templates/home.html
@@ -299,7 +299,6 @@
       <div id="email-required-modal" class="modal fade">
         <form action="{{ url("social:complete", backend=partial_backend_name) }}" method="post" role="form">
           <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
-          <input type="hidden" name="partial_token" value="{{ partial_token }}">
           <div class="modal-dialog">
             <div class="modal-content">
               <div class="modal-header">
@@ -327,7 +326,6 @@
       <div id="country-required-modal" class="modal fade">
         <form action="{{ url("social:complete", backend=partial_backend_name) }}" method="post" role="form">
           <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
-          <input type="hidden" name="partial_token" value="{{ partial_token }}">
           <div class="modal-dialog">
             <div class="modal-content">
               <div class="modal-header">
@@ -355,7 +353,6 @@
       <div id="city-required-modal" class="modal fade">
         <form action="{{ url("social:complete", backend=partial_backend_name) }}" method="post" role="form">
           <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
-          <input type="hidden" name="partial_token" value="{{ partial_token }}">
           <div class="modal-dialog">
             <div class="modal-content">
               <div class="modal-header">


### PR DESCRIPTION
# The Problem

I created this PR to demonstrate a scenario in which the `AuthMissingParameter` happens. This is caused by the logic [here](https://github.com/python-social-auth/social-core/blob/417b607fe4fa0e4cb2f490938d9902c7a889e427/social_core/strategy.py#L95) that removes the `partial_token` from the session without checking that the correct token is being removed.

```python
    def clean_partial_pipeline(self, token):
        # this is the actual Partial object being removed, so this is fine
        self.storage.partial.destroy(token) 
        # THIS however doesn't check which token is being removed.. THIS is the problem
        self.session_pop(PARTIAL_TOKEN_SESSION_NAME)
```

It really should be something like...
```python
    def clean_partial_pipeline(self, token):
        self.storage.partial.destroy(token)
        if self.session_get((PARTIAL_TOKEN_SESSION_NAME) == token:
           self.session_pop(PARTIAL_TOKEN_SESSION_NAME)
```
This only manifests itself when you leave the pipeline more than once, each with functions that save partial data. The problem is that the `partial_token` for the second step of the pipeline gets cleaned up when the `partial_token` for the first partial function is being removed.

In essence this clean up sequence is caused because the partial for the **next** step is [saved](https://github.com/python-social-auth/social-core/blob/417b607fe4fa0e4cb2f490938d9902c7a889e427/social_core/pipeline/partial.py#L37) before the clean up happens. Now because [this logic](https://github.com/python-social-auth/social-core/blob/417b607fe4fa0e4cb2f490938d9902c7a889e427/social_core/strategy.py#L95) doesn't look at the `partial_token` on the session, it inadvertently ends up cleaning up the **wrong** token. It cleans up the **new** token. 

# The Workaround

It's possible to work around this problem (as this repo does) by always passing up the `partial_token` in the `/complete/<backend>/` endpoint so that Social Core is able to load the right partial token.

To show the problem, we simply need to stop doing that. For this PR, the Django `home.html` template was edited and I removed all the lines that added the `partial_token` to the form.

```html
<input type="hidden" name="partial_token" value="{{ partial_token }}">
```

In this case I removed it for Country, City and Email. I was able to reproduce by connecting a Google Account. It prompts for Country and City, then gives us the `AuthMissingParameter` error.

# The Fix

Change the logic to check the token in the session to prevent popping the wrong token. 

```python
    def clean_partial_pipeline(self, token):
        self.storage.partial.destroy(token)
        current_token_in_session = self.session_get(PARTIAL_TOKEN_SESSION_NAME)
        if current_token_in_session == token:
            self.session_pop(PARTIAL_TOKEN_SESSION_NAME)
```

I have a branch with the fix. This commit can be directly installed to test drive the fix.

```bash
pip install -e git+git://github.com/jaywhy13/social-core.git@561642bf7ea079cdf57ff0fda15c74a1fcc5eba4#egg=social-core
```
